### PR TITLE
Miscellaneous Refactorings

### DIFF
--- a/Tests/DataHelper.php
+++ b/Tests/DataHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/CheckboxFieldTest.php
+++ b/Tests/Field/CheckboxFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/CheckboxesFieldTest.php
+++ b/Tests/Field/CheckboxesFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/DatabaseConnectionFieldTest.php
+++ b/Tests/Field/DatabaseConnectionFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/EmailFieldTest.php
+++ b/Tests/Field/EmailFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/FileFieldTest.php
+++ b/Tests/Field/FileFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/FileListFieldTest.php
+++ b/Tests/Field/FileListFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/FolderListFieldTest.php
+++ b/Tests/Field/FolderListFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/GroupedListFieldTest.php
+++ b/Tests/Field/GroupedListFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/HiddenFieldTest.php
+++ b/Tests/Field/HiddenFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/ImageListFieldTest.php
+++ b/Tests/Field/ImageListFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/IntegerFieldTest.php
+++ b/Tests/Field/IntegerFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/LanguageFieldTest.php
+++ b/Tests/Field/LanguageFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/ListFieldTest.php
+++ b/Tests/Field/ListFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/PasswordFieldTest.php
+++ b/Tests/Field/PasswordFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/RadioFieldTest.php
+++ b/Tests/Field/RadioFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/SpacerFieldTest.php
+++ b/Tests/Field/SpacerFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/TelFieldTest.php
+++ b/Tests/Field/TelFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/TelFieldTest.php
+++ b/Tests/Field/TelFieldTest.php
@@ -28,7 +28,7 @@ class TelFieldTest extends \PHPUnit_Framework_TestCase
 				array(
 					'tag' => 'input',
 					'attributes' => array(
-						'type' => 'text',
+						'type' => 'tel',
 						'id' => 'myId',
 						'name' => 'myName',
 					)
@@ -39,7 +39,7 @@ class TelFieldTest extends \PHPUnit_Framework_TestCase
 				array(
 					'tag' => 'input',
 					'attributes' => array(
-						'type' => 'text',
+						'type' => 'tel',
 						'id' => 'myId',
 						'size' => '0',
 						'maxlength' => '0',

--- a/Tests/Field/TextFieldTest.php
+++ b/Tests/Field/TextFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/TextareaFieldTest.php
+++ b/Tests/Field/TextareaFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/TimezoneFieldTest.php
+++ b/Tests/Field/TimezoneFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/UrlFieldTest.php
+++ b/Tests/Field/UrlFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Field/UrlFieldTest.php
+++ b/Tests/Field/UrlFieldTest.php
@@ -28,7 +28,7 @@ class UrlFieldTest extends \PHPUnit_Framework_TestCase
 				array(
 					'tag' => 'input',
 					'attributes' => array(
-						'type' => 'text',
+						'type' => 'url',
 						'id' => 'myId',
 						'name' => 'myName',
 					)
@@ -39,7 +39,7 @@ class UrlFieldTest extends \PHPUnit_Framework_TestCase
 				array(
 					'tag' => 'input',
 					'attributes' => array(
-						'type' => 'text',
+						'type' => 'url',
 						'id' => 'myId',
 						'size' => '0',
 						'maxlength' => '0',

--- a/Tests/Field/data/language/en-GB/en-GB.localise.php
+++ b/Tests/Field/data/language/en-GB/en-GB.localise.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/Tests/Field/data/language/en-GB/en-GB.xml
+++ b/Tests/Field/data/language/en-GB/en-GB.xml
@@ -6,7 +6,7 @@
     <author>Joomla! Project</author>
     <authorEmail>admin@joomla.org</authorEmail>
     <authorUrl>www.joomla.org</authorUrl>
-    <copyright>Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.</copyright>
+    <copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>en-GB site language</description>
     <files>

--- a/Tests/FieldTest.php
+++ b/Tests/FieldTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/FieldTest.php
+++ b/Tests/FieldTest.php
@@ -217,7 +217,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$equals = '<label id="title_id-lbl" for="title_id" class="hasTip required" ' .
-			'title="Title::The title.">Title<span class="star">&#160;*</span></label>';
+			'title="Title::The title.">Title</label>';
 
 		$this->assertEquals(
 			$equals,
@@ -407,7 +407,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$this->assertEquals(
-			'inputbox required',
+			'inputbox',
 			(string) $title['class'],
 			'Line:' . __LINE__ . ' The property should be set from the XML.'
 		);
@@ -434,8 +434,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 
-		$equals = '<label id="title_id-lbl" for="title_id" class="hasTip required" title="Title::The title.">' .
-			'Title<span class="star">&#160;*</span></label>';
+		$equals = '<label id="title_id-lbl" for="title_id" class="hasTip required" title="Title::The title.">Title</label>';
 
 		$this->assertEquals(
 			$equals,
@@ -558,7 +557,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$this->assertEquals(
-			'required',
+			'',
 			$field->element['class'],
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);

--- a/Tests/FieldTest.php
+++ b/Tests/FieldTest.php
@@ -69,7 +69,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertTrue(
 			$field instanceof \Joomla\Form\Field,
-			'Line:' . __LINE__ . ' The JFormField constuctor should return a JFormField object.'
+			'Line:' . __LINE__ . ' The \\Joomla\\Form\\Field constuctor should return a \\Joomla\\Form\\Field object.'
 		);
 
 		$this->assertThat(

--- a/Tests/FormHelperTest.php
+++ b/Tests/FormHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -24,8 +24,9 @@ class FormHelperTest extends \PHPUnit_Framework_TestCase
 		/** @var \Composer\Autoload\ClassLoader $loader */
 		$loader = include dirname(__DIR__) . '/vendor/autoload.php';
 
-		// Add our test fields to the autoload paths for testing
+		// Add our test fields and rules to the autoload paths for testing
 		$loader->addPsr4('Foo\\Form\\Field\\', __DIR__ . '/_testfields');
+		$loader->addPsr4('Foo\\Form\\Rule\\', __DIR__ . '/_testrules');
 	}
 
 	/**
@@ -111,6 +112,12 @@ class FormHelperTest extends \PHPUnit_Framework_TestCase
 			"Joomla\\Form\\Rule\\UrlRule",
 			FormHelper::loadRuleClass('joomla.url'),
 			'Line:' . __LINE__ . ' loadRuleClass should return the correct class.'
+		);
+
+		$this->assertEquals(
+			"Foo\\Form\\Rule\\CustomRule",
+			FormHelper::loadRuleClass('foo.custom'),
+			'Line:' . __LINE__ . ' loadRuleClass should return the correct custom class.'
 		);
 	}
 }

--- a/Tests/FormHelperTest.php
+++ b/Tests/FormHelperTest.php
@@ -102,13 +102,13 @@ class FormHelperTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$this->assertEquals(
-			"Joomla\\Form\\Rule\\Email",
+			"Joomla\\Form\\Rule\\EmailRule",
 			FormHelper::loadRuleClass('email'),
 			'Line:' . __LINE__ . ' loadRuleClass should return the correct class.'
 		);
 
 		$this->assertEquals(
-			"Joomla\\Form\\Rule\\Url",
+			"Joomla\\Form\\Rule\\UrlRule",
 			FormHelper::loadRuleClass('joomla.url'),
 			'Line:' . __LINE__ . ' loadRuleClass should return the correct class.'
 		);

--- a/Tests/FormTest.php
+++ b/Tests/FormTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/FormTest.php
+++ b/Tests/FormTest.php
@@ -1037,7 +1037,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$this->assertEquals(
-			'<input type="text" name="title" id="title_id" value="The Title" class="inputbox required"/>',
+			'<input type="text" name="title" id="title_id" value="The Title" class="inputbox"/>',
 			$form->getInput('title', null, 'The Title'),
 			'Line:' . __LINE__ . ' The method should return a simple input text field.'
 		);
@@ -1120,7 +1120,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertEquals(
 			'<label id="title_id-lbl" for="title_id" class="hasTip required" ' .
-				'title="Title::The title.">Title<span class="star">&#160;*</span></label>',
+				'title="Title::The title.">Title</label>',
 			$form->getLabel('title'),
 			'Line:' . __LINE__ . ' The method should return a simple label field.'
 		);

--- a/Tests/Html/SelectTest.php
+++ b/Tests/Html/SelectTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Html/SelectTest.php
+++ b/Tests/Html/SelectTest.php
@@ -172,8 +172,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
 	 * @param   mixed    $attribs    Additional HTML attributes for the <select> tag. This
 	 *                               can be an array of attributes, or an array of options. Treated as options
 	 *                               if it is the last argument passed. Valid options are:
-	 *                               Format options, see {@see JHtml::$formatOptions}.
-	 *                               Selection options, see {@see JHtml$select->options()}.
+	 *                               Format options, see {@see Joomla\Form\Html\Select::$formatOptions}.
+	 *                               Selection options, see {@see Joomla\Form\Html\Select::options()}.
 	 *                               list.attr, string|array: Additional attributes for the select
 	 *                               element.
 	 *                               id, string: Value to use as the select element id attribute.
@@ -885,7 +885,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
 	 * @param   mixed    $optKey     If a string, this is the name of the object variable for
 	 *                               the option value. If null, the index of the array of objects is used. If
 	 *                               an array, this is a set of options, as key/value pairs. Valid options are:
-	 *                               -Format options, {@see JHtml::$formatOptions}.
+	 *                               -Format options, {@see \Joomla\Form\Html\Select::$formatOptions}.
 	 *                               -groups: Boolean. If set, looks for keys with the value
 	 *                                "&lt;optgroup>" and synthesizes groups from them. Deprecated. Defaults
 	 *                                true for backwards compatibility.

--- a/Tests/Rule/BooleanRuleTest.php
+++ b/Tests/Rule/BooleanRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/BooleanRuleTest.php
+++ b/Tests/Rule/BooleanRuleTest.php
@@ -7,15 +7,15 @@
 namespace Joomla\Form\Tests\Rule;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Boolean as RuleBoolean;
+use Joomla\Form\Rule\BooleanRule;
 
 /**
- * Test class for Joomla\Form\Rule\Boolean.
+ * Test class for Joomla\Form\Rule\BooleanRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Boolean
+ * @coversDefaultClass  Joomla\Form\Rule\BooleanRule
  * @since  1.0
  */
-class BooleanTest extends \PHPUnit_Framework_TestCase
+class BooleanRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
 	 * Test data for testing of Joomla\Form\Rule\Boolean::test method.
@@ -45,7 +45,7 @@ class BooleanTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Boolean::test method.
+	 * Test the Joomla\Form\Rule\BooleanRule::test method.
 	 *
 	 * @param   string   $value           @todo
 	 * @param   boolean  $expectedOutput  @todo
@@ -56,7 +56,7 @@ class BooleanTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testBoolean($value, $expectedOutput)
 	{
-		$rule = new RuleBoolean;
+		$rule = new BooleanRule;
 		$xml = new \SimpleXmlElement('<field name="foo" />');
 
 		$this->assertEquals(
@@ -68,14 +68,14 @@ class BooleanTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Boolean::test method.
+	 * Test the Joomla\Form\Rule\BooleanRule::test method.
 	 *
 	 * @covers             Joomla\Form\Rule::test
 	 * @expectedException  UnexpectedValueException
 	 */
 	public function testRuleEmptyRegexException()
 	{
-		$rule = new RuleBoolean;
+		$rule = new BooleanRule;
 		$xml = new \SimpleXmlElement('<field name="foo" />');
 
 		TestHelper::setValue($rule, 'regex', '');

--- a/Tests/Rule/ColorRuleTest.php
+++ b/Tests/Rule/ColorRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/ColorRuleTest.php
+++ b/Tests/Rule/ColorRuleTest.php
@@ -6,17 +6,17 @@
 
 namespace Joomla\Form\Tests\Rule;
 
-use Joomla\Form\Rule\Color as RuleColor;
+use Joomla\Form\Rule\ColorRule;
 
 /**
- * Test class for Joomla\Form\Rule\Color.
+ * Test class for Joomla\Form\Rule\ColorRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Color
+ * @coversDefaultClass  Joomla\Form\Rule\ColorRule
  */
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test data for testing of Joomla\Form\Rule\Color::test method.
+	 * Test data for testing of Joomla\Form\Rule\ColorRule::test method.
 	 *
 	 * @return  array
 	 */
@@ -42,7 +42,7 @@ class ColorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Color::test method.
+	 * Test the Joomla\Form\Rule\ColorRule::test method.
 	 *
 	 * @param   string   $color           @todo
 	 * @param   boolean  $expectedOutput  @todo
@@ -52,7 +52,7 @@ class ColorTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testColor($color, $expectedOutput)
 	{
-		$rule = new RuleColor;
+		$rule = new ColorRule;
 		$xml = new \SimpleXmlElement('<field name="color" />');
 		$this->assertThat(
 			$rule->test($xml, $color),

--- a/Tests/Rule/EmailRuleTest.php
+++ b/Tests/Rule/EmailRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/EmailRuleTest.php
+++ b/Tests/Rule/EmailRuleTest.php
@@ -7,23 +7,23 @@
 namespace Joomla\Form\Tests\Rule;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Email as RuleEmail;
+use Joomla\Form\Rule\EmailRule;
 
 /**
- * Test class for Joomla\Form\Rule\Email.
+ * Test class for Joomla\Form\Rule\EmailRule.
  *
- * @coversDefaultClass Joomla\Form\Rule\Email
+ * @coversDefaultClass Joomla\Form\Rule\EmailRule
  */
-class EmailTest extends \PHPUnit_Framework_TestCase
+class EmailRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test the Joomla\Form\Rule\Email::test method.
+	 * Test the Joomla\Form\Rule\EmailRule::test method.
 	 *
 	 * @covers  ::test
 	 */
 	public function testEmail()
 	{
-		$rule = new RuleEmail;
+		$rule = new EmailRule;
 		$xml = simplexml_load_string('<form><field name="email1" /><field name="email2" unique="true" /></form>');
 
 		// Test fail conditions.
@@ -87,7 +87,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testEmailData($emailAddress, $expectedResult)
 	{
-		$rule = new RuleEmail;
+		$rule = new EmailRule;
 		$xml = simplexml_load_string('<form><field name="email1" /></form>');
 		$this->assertEquals(
 			$rule->test($xml->field[0], $emailAddress),
@@ -122,7 +122,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testEmailData2($emailAddress, $expectedResult)
 	{
-		$rule = new RuleEmail;
+		$rule = new EmailRule;
 		$xml = simplexml_load_string('<form><field name="email1" multiple="multiple" /></form>');
 		$this->assertEquals(
 			$rule->test($xml->field[0], $emailAddress),
@@ -158,7 +158,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testEmailData3($emailAddress, $expectedResult)
 	{
-		$rule = new RuleEmail;
+		$rule = new EmailRule;
 		$xml = simplexml_load_string('<form><field name="email1" tld="tld" /></form>');
 		$this->assertEquals(
 			$rule->test($xml->field[0], $emailAddress),

--- a/Tests/Rule/EqualsRuleTest.php
+++ b/Tests/Rule/EqualsRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/EqualsRuleTest.php
+++ b/Tests/Rule/EqualsRuleTest.php
@@ -7,24 +7,24 @@
 namespace Joomla\Form\Tests\Rule;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Equals as RuleEquals;
+use Joomla\Form\Rule\EqualsRule;
 use Joomla\Registry\Registry;
 
 /**
- * Test class for Joomla\Form\Rule\Equals.
+ * Test class for Joomla\Form\Rule\EqualsRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Equals
+ * @coversDefaultClass  Joomla\Form\Rule\EqualsRule
  */
-class EqualsTest extends \PHPUnit_Framework_TestCase
+class EqualsRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test the Joomla\Form\Rule\Equals::test method.
+	 * Test the Joomla\Form\Rule\EqualsRule::test method.
 	 *
 	 * @covers  ::test
 	 */
 	public function testEquals()
 	{
-		$rule = new RuleEquals;
+		$rule = new EqualsRule;
 		$field = new \SimpleXmlElement('<field name="foo" field="bar" />');
 
 		// Test fail conditions.
@@ -43,14 +43,14 @@ class EqualsTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Equals::test method.
+	 * Test the Joomla\Form\Rule\EqualsRule::test method.
 	 *
 	 * @covers             ::test
 	 * @expectedException  UnexpectedValueException
 	 */
 	public function testEqualsNoField()
 	{
-		$rule = new RuleEquals;
+		$rule = new EqualsRule;
 		$field = new \SimpleXmlElement('<field name="foo" />');
 
 		// Test fail conditions.
@@ -59,14 +59,14 @@ class EqualsTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Equals::test method.
+	 * Test the Joomla\Form\Rule\EqualsRule::test method.
 	 *
 	 * @covers             ::test
 	 * @expectedException  InvalidArgumentException
 	 */
 	public function testEqualsNullRegistry()
 	{
-		$rule = new RuleEquals;
+		$rule = new EqualsRule;
 		$field = new \SimpleXmlElement('<field name="foo" field="bar" />');
 
 		// Test fail conditions.

--- a/Tests/Rule/OptionsRuleTest.php
+++ b/Tests/Rule/OptionsRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/OptionsRuleTest.php
+++ b/Tests/Rule/OptionsRuleTest.php
@@ -7,24 +7,23 @@
 namespace Joomla\Form\Tests;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Options as RuleOptions;
+use Joomla\Form\Rule\OptionsRule;
 
 /**
- * Test class for Joomla\Form\Rule\Options.
+ * Test class for Joomla\Form\Rule\OptionsRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Options
- * @since  1.0
+ * @coversDefaultClass  Joomla\Form\Rule\OptionsRule
  */
-class OptionsTest extends \PHPUnit_Framework_TestCase
+class OptionsRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test the Joomla\Form\Rule\Options::test method.
+	 * Test the Joomla\Form\Rule\OptionsRule::test method.
 	 *
 	 * @covers ::test
 	 */
 	public function testOptions()
 	{
-		$rule = new RuleOptions;
+		$rule = new OptionsRule;
 		$xml = new \SimpleXmlElement(
 			'<field name="field1"><option value="value1">Value1</option><option value="value2">Value2</option></field>'
 		);

--- a/Tests/Rule/TelRuleTest.php
+++ b/Tests/Rule/TelRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/TelRuleTest.php
+++ b/Tests/Rule/TelRuleTest.php
@@ -7,17 +7,17 @@
 namespace Joomla\Form\Tests\Rule;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Tel as RuleTel;
+use Joomla\Form\Rule\TelRule;
 
 /**
- * Test class for Joomla\Form\Rule\Tel.
+ * Test class for Joomla\Form\Rule\TelRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Tel
+ * @coversDefaultClass  Joomla\Form\Rule\TelRule
  */
-class TelTest extends \PHPUnit_Framework_TestCase
+class TelRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test data for testing of Joomla\Form\Rule\Tel::test method.
+	 * Test data for testing of Joomla\Form\Rule\TelRule::test method.
 	 *
 	 * @return  array
 	 */
@@ -192,7 +192,7 @@ class TelTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Tel::test method.
+	 * Test the Joomla\Form\Rule\TelRule::test method.
 	 *
 	 * @param   string  $xml         @todo
 	 * @param   array   $assertions  @todo
@@ -202,7 +202,7 @@ class TelTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testTel($xml, $assertions)
 	{
-		$rule = new RuleTel;
+		$rule = new TelRule;
 		$field = new \SimpleXmlElement($xml);
 
 		foreach ($assertions as $assertion)

--- a/Tests/Rule/UrlRuleTest.php
+++ b/Tests/Rule/UrlRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/Rule/UrlRuleTest.php
+++ b/Tests/Rule/UrlRuleTest.php
@@ -7,17 +7,17 @@
 namespace Joomla\Form\Tests\Rule;
 
 use Joomla\Test\TestHelper;
-use Joomla\Form\Rule\Url as RuleUrl;
+use Joomla\Form\Rule\UrlRule;
 
 /**
- * Test class for Joomla\Form\Rule\Url.
+ * Test class for Joomla\Form\Rule\UrlRule.
  *
- * @coversDefaultClass  Joomla\Form\Rule\Url
+ * @coversDefaultClass  Joomla\Form\Rule\UrlRule
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlRuleTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test data for testing of Joomla\Form\Rule\Url::test method.
+	 * Test data for testing of Joomla\Form\Rule\UrlRule::test method.
 	 *
 	 * @return  array
 	 */
@@ -64,7 +64,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Form\Rule\Url::test method.
+	 * Test the Joomla\Form\Rule\UrlRule::test method.
 	 *
 	 * @param   string   $caseDescription  @todo
 	 * @param   int      $xmlfield         @todo
@@ -76,7 +76,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testUrl($caseDescription, $xmlfield, $url, $expected)
 	{
-		$rule = new RuleUrl;
+		$rule = new UrlRule;
 
 		// The field allows you to optionally limit the accepted schemes to a specific list.
 		// Url1 tests without a list, Url2 tests with a list.

--- a/Tests/_testfields/BarField.php
+++ b/Tests/_testfields/BarField.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/_testfields/Modal/BarField.php
+++ b/Tests/_testfields/Modal/BarField.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/_testfields/Modal/foo.php
+++ b/Tests/_testfields/Modal/foo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/_testfields/foo.php
+++ b/Tests/_testfields/foo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/_testfields/test.php
+++ b/Tests/_testfields/test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/Tests/_testrules/CustomRule.php
+++ b/Tests/_testrules/CustomRule.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Form\Rule;
+namespace Foo\Form\Rule;
 
 /**
  * Form Rule class for the Joomla Framework.
  *
  * @since  1.0
  */
-class Custom extends \Joomla\Form\Rule
+class CustomRule extends \Joomla\Form\Rule
 {
 	/**
 	 * The regular expression to use in testing a form field value.

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,10 +1,9 @@
 <?php
 /**
- * Unit test runner bootstrap file for the Joomla Framework.
+ * Part of the Joomla Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
- * @link       http://www.phpunit.de/manual/current/en/installation.html
  */
 
 // Fix magic quotes.

--- a/Tests/inspectors.php
+++ b/Tests/inspectors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -379,9 +379,9 @@ abstract class Field
 		$readonly = (string) $element['readonly'];
 
 		// Set the required, disabled and validation options.
-		$this->required = ($required == 'true' || $required == 'required' || $required == '1');
-		$this->disabled = ($disabled == 'true' || $disabled == 'disabled' || $disabled == '1');
-		$this->readonly = ($readonly == 'true' || $readonly == 'readonly' || $readonly == '1');
+		$this->required = $required == 'true';
+		$this->disabled = $disabled == 'true';
+		$this->readonly = $readonly == 'true';
 		$this->validate = (string) $element['validate'];
 
 		// Add the required class if the field is required.
@@ -416,10 +416,9 @@ abstract class Field
 		$this->hidden = ((string) $element['type'] == 'hidden' || (string) $element['hidden'] == 'true');
 
 		// Determine whether to translate the field label, description, and options.
-		$this->translateLabel = !((string) $this->element['translate_label'] == 'false' || (string) $this->element['translate_label'] == '0');
-		$this->translateDescription = !((string) $this->element['translate_description'] == 'false'
-			|| (string) $this->element['translate_description'] == '0');
-		$this->translateOptions = !((string) $this->element['translate_options'] == 'false' || (string) $this->element['translate_options'] == '0');
+		$this->translateLabel = !(string) $this->element['translate_label'] == 'false';
+		$this->translateDescription = !(string) $this->element['translate_description'] == 'false';
+		$this->translateOptions = !(string) $this->element['translate_options'] == 'false';
 
 		// Set the group of the field.
 		$this->group = $group;

--- a/src/Field.php
+++ b/src/Field.php
@@ -384,22 +384,6 @@ abstract class Field
 		$this->readonly = $readonly == 'true';
 		$this->validate = (string) $element['validate'];
 
-		// Add the required class if the field is required.
-		if ($this->required)
-		{
-			if ($class)
-			{
-				if (strpos($class, 'required') === false)
-				{
-					$this->element['class'] = $class . ' required';
-				}
-			}
-			else
-			{
-				$this->element->addAttribute('class', 'required');
-			}
-		}
-
 		// Set the multiple values option.
 		$this->multiple = ($multiple == 'true' || $multiple == 'multiple');
 
@@ -576,14 +560,7 @@ abstract class Field
 		}
 
 		// Add the label text and closing tag.
-		if ($this->required)
-		{
-			$label .= '>' . $text . '<span class="star">&#160;*</span></label>';
-		}
-		else
-		{
-			$label .= '>' . $text . '</label>';
-		}
+		$label .= '>' . $text . '</label>';
 
 		return $label;
 	}

--- a/src/Field.php
+++ b/src/Field.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -15,7 +15,7 @@ use Joomla\Language\Text;
 use SimpleXMLElement;
 
 /**
- * Abstract Form Field class for the Joomla Framework.
+ * Abstract Form Field class for the Joomla! Framework.
  *
  * @since  1.0
  */
@@ -110,8 +110,9 @@ abstract class Field
 	protected $label;
 
 	/**
-	 * The multiple state for the form field.  If true then multiple values are allowed for the
-	 * field.  Most often used for list field types.
+	 * The multiple state for the form field.
+	 *
+	 * If true then multiple values are allowed for the field.  Most often used for list field types.
 	 *
 	 * @var    boolean
 	 * @since  1.0
@@ -143,8 +144,9 @@ abstract class Field
 	protected $group;
 
 	/**
-	 * The required state for the form field.  If true then there must be a value for the field to
-	 * be considered valid.
+	 * The required state for the form field.
+	 *
+	 * If true then there must be a value for the field to be considered valid.
 	 *
 	 * @var    boolean
 	 * @since  1.0
@@ -152,8 +154,9 @@ abstract class Field
 	protected $required = false;
 
 	/**
-	 * The disabled state for the form field.  If true then there must not be a possibility
-	 * to change the pre-selected value, and the value must not be submitted by the browser.
+	 * The disabled state for the form field.
+	 *
+	 * If true then there must not be a possibility to change the pre-selected value, and the value must not be submitted by the browser.
 	 *
 	 * @var    boolean
 	 * @since  1.0
@@ -161,8 +164,9 @@ abstract class Field
 	protected $disabled = false;
 
 	/**
-	 * The readonly state for the form field.  If true then there must not be a possibility
-	 * to change the pre-selected value, and the value must submitted by the browser.
+	 * The readonly state for the form field.
+	 *
+	 * If true then there must not be a possibility to change the pre-selected value, and the value must submitted by the browser.
 	 *
 	 * @var    boolean
 	 * @since  1.0
@@ -178,8 +182,9 @@ abstract class Field
 	protected $type;
 
 	/**
-	 * The validation method for the form field.  This value will determine which method is used
-	 * to validate the value for a field.
+	 * The validation method for the form field.
+	 *
+	 * This value will determine which method is used to validate the value for a field.
 	 *
 	 * @var    string
 	 * @since  1.0

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Single check box field.
- * This is a boolean field with null for false and the specified option for true
+ * Checkbox Form Field class for the Joomla! Framework.
+ *
+ * Single check box field. This is a boolean field with null for false and the specified option for true.
  *
  * @link   http://www.w3.org/TR/html-markup/input.checkbox.html#input.checkbox
  * @see    \Joomla\Form\Field\CheckboxesField

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -14,7 +14,7 @@ namespace Joomla\Form\Field;
  * This is a boolean field with null for false and the specified option for true
  *
  * @link   http://www.w3.org/TR/html-markup/input.checkbox.html#input.checkbox
- * @see    JFormFieldCheckboxes
+ * @see    \Joomla\Form\Field\CheckboxesField
  * @since  1.0
  */
 class CheckboxField extends \Joomla\Form\Field

--- a/src/Field/CheckboxesField.php
+++ b/src/Field/CheckboxesField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,9 +11,9 @@ namespace Joomla\Form\Field;
 use Joomla\Form\Html\Select as HtmlSelect;
 
 /**
- * Form Field class for the Joomla Framework.
- * Displays options as a list of check boxes.
- * Multiselect may be forced to be true.
+ * Checkboxes Form Field class for the Joomla! Framework.
+ *
+ * Displays options as a list of check boxes. Multiselect may be forced to be true.
  *
  * @see    \Joomla\Form\Field\CheckboxField
  * @since  1.0

--- a/src/Field/CheckboxesField.php
+++ b/src/Field/CheckboxesField.php
@@ -15,7 +15,7 @@ use Joomla\Form\Html\Select as HtmlSelect;
  * Displays options as a list of check boxes.
  * Multiselect may be forced to be true.
  *
- * @see    JFormFieldCheckbox
+ * @see    \Joomla\Form\Field\CheckboxField
  * @since  1.0
  */
 class CheckboxesField extends \Joomla\Form\Field

--- a/src/Field/DatabaseConnectionField.php
+++ b/src/Field/DatabaseConnectionField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,11 +11,11 @@ namespace Joomla\Form\Field;
 use Joomla\Database\DatabaseDriver;
 
 /**
- * Form Field class for the Joomla Framework.
- * Provides a list of available database connections, optionally limiting to
- * a given list.
+ * Database Connection Form Field class for the Joomla! Framework.
  *
- * @see    Joomla\Database\DatabaseDriver
+ * Provides a list of available database connections, optionally limiting to a given list.
+ *
+ * @see    \Joomla\Database\DatabaseDriver
  * @since  1.0
  */
 class DatabaseConnectionField extends ListField
@@ -32,12 +32,12 @@ class DatabaseConnectionField extends ListField
 	 * Method to get the list of database options.
 	 *
 	 * This method produces a drop down list of available databases supported
-	 * by DatabaseDriver classes that are also supported by the application.
+	 * by {@link \Joomla\Database\DatabaseDriver} classes that are also supported by the application.
 	 *
 	 * @return  array    The field option objects.
 	 *
 	 * @since   1.0
-	 * @see		Joomla\Database\DatabaseDriver
+	 * @see		\Joomla\Database\DatabaseDriver
 	 */
 	protected function getOptions()
 	{

--- a/src/Field/EmailField.php
+++ b/src/Field/EmailField.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
+ * E-mail Form Field class for the Joomla! Framework.
+ *
  * Provides and input field for e-mail addresses
  *
  * @link   http://www.w3.org/TR/html-markup/input.email.html#input.email
- * @see    \Joomla\Form\Rule\Email
+ * @see    \Joomla\Form\Rule\EmailRule
  * @since  1.0
  */
 class EmailField extends \Joomla\Form\Field

--- a/src/Field/EmailField.php
+++ b/src/Field/EmailField.php
@@ -13,7 +13,7 @@ namespace Joomla\Form\Field;
  * Provides and input field for e-mail addresses
  *
  * @link   http://www.w3.org/TR/html-markup/input.email.html#input.email
- * @see    JFormRuleEmail
+ * @see    \Joomla\Form\Rule\Email
  * @since  1.0
  */
 class EmailField extends \Joomla\Form\Field

--- a/src/Field/FileField.php
+++ b/src/Field/FileField.php
@@ -35,7 +35,6 @@ class FileField extends \Joomla\Form\Field
 	 * @since   1.0
 	 *
 	 * @note    The field does not include an upload mechanism.
-	 * @see     JFormFieldMedia
 	 */
 	protected function getInput()
 	{

--- a/src/Field/FileField.php
+++ b/src/Field/FileField.php
@@ -1,16 +1,17 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Provides an input field for files
+ * File Form Field class for the Joomla! Framework.
+ *
+ * Provides an input field for files.
  *
  * @link   http://www.w3.org/TR/html-markup/input.file.html#input.file
  * @since  1.0
@@ -33,7 +34,6 @@ class FileField extends \Joomla\Form\Field
 	 * @return  string  The field input markup.
 	 *
 	 * @since   1.0
-	 *
 	 * @note    The field does not include an upload mechanism.
 	 */
 	protected function getInput()

--- a/src/Field/FileListField.php
+++ b/src/Field/FileListField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -13,7 +13,9 @@ use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
 
 /**
- * Supports an HTML select list of files
+ * File List Form Field class for the Joomla! Framework.
+ *
+ * Supports an HTML select list of files.
  *
  * @since  1.0
  */
@@ -29,6 +31,7 @@ class FileListField extends ListField
 
 	/**
 	 * Method to get the list of files for the field options.
+	 *
 	 * Specify the target directory with a directory attribute
 	 * Attributes allow an exclude mask and stripping of extensions from file name.
 	 * Default attribute may optionally be set to null (no file) or -1 (use a default).

--- a/src/Field/FolderListField.php
+++ b/src/Field/FolderListField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -12,7 +12,9 @@ use Joomla\Form\Html\Select as HtmlSelect;
 use Joomla\Filesystem\Folder;
 
 /**
- * Supports an HTML select list of folder
+ * Folder List Form Field class for the Joomla! Framework.
+ *
+ * Supports an HTML select list of folders
  *
  * @since  1.0
  */

--- a/src/Field/GroupedListField.php
+++ b/src/Field/GroupedListField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,7 +11,8 @@ namespace Joomla\Form\Field;
 use Joomla\Form\Html\Select as HtmlSelect;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Grouped List Form Field class for the Joomla! Framework.
+ *
  * Provides a grouped list select field.
  *
  * @since  1.0

--- a/src/Field/GroupedListField.php
+++ b/src/Field/GroupedListField.php
@@ -9,7 +9,6 @@
 namespace Joomla\Form\Field;
 
 use Joomla\Form\Html\Select as HtmlSelect;
-use UnexpectedValueException;
 
 /**
  * Form Field class for the Joomla Framework.
@@ -33,7 +32,7 @@ class GroupedListField extends \Joomla\Form\Field
 	 * @return  array  The field option objects as a nested array in groups.
 	 *
 	 * @since   1.0
-	 * @throws  UnexpectedValueException
+	 * @throws  \UnexpectedValueException
 	 */
 	protected function getGroups()
 	{
@@ -130,7 +129,10 @@ class GroupedListField extends \Joomla\Form\Field
 
 				// Unknown element type.
 				default:
-					throw new UnexpectedValueException(sprintf('Unsupported element %s in JFormFieldGroupedList', $element->getName()), 500);
+					throw new \UnexpectedValueException(
+						sprintf('Unsupported element %1$s in %2$s', $element->getName(), __CLASS__),
+						500
+					);
 			}
 		}
 

--- a/src/Field/HiddenField.php
+++ b/src/Field/HiddenField.php
@@ -1,16 +1,17 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Provides a hidden field
+ * Hidden Form Field class for the Joomla! Framework.
+ *
+ * Provides a hidden field.
  *
  * @link   http://www.w3.org/TR/html-markup/input.hidden.html#input.hidden
  * @since  1.0

--- a/src/Field/ImageListField.php
+++ b/src/Field/ImageListField.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Supports an HTML select list of image
+ * File List Form Field class for the Joomla! Framework.
+ *
+ * Supports an HTML select list of images
  *
  * @since  1.0
  */
@@ -25,6 +27,7 @@ class ImageListField extends FileListField
 
 	/**
 	 * Method to get the list of images field options.
+	 *
 	 * Use the filter attribute to specify allowable file extensions.
 	 *
 	 * @return  array  The field option objects.

--- a/src/Field/IntegerField.php
+++ b/src/Field/IntegerField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,7 +11,8 @@ namespace Joomla\Form\Field;
 use Joomla\Form\Html\Select as HtmlSelect;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Integer Form Field class for the Joomla! Framework.
+ *
  * Provides a select list of integers with specified first, last and step values.
  *
  * @since  1.0

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
-use Joomla\Language\Language;
+use Joomla\Language\LanguageHelper;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Language Form Field class for the Joomla! Framework.
+ *
  * Supports a list of installed application languages
  *
  * @since  1.0
@@ -60,8 +61,8 @@ class LanguageField extends ListField
 	{
 		$list = array();
 
-		// Cache activation
-		$langs = Language::getKnownLanguages($basePath);
+		$langHelper = new LanguageHelper;
+		$langs      = $langHelper->getKnownLanguages($basePath);
 
 		foreach ($langs as $lang => $metadata)
 		{

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -14,7 +14,6 @@ use Joomla\Language\Language;
  * Form Field class for the Joomla Framework.
  * Supports a list of installed application languages
  *
- * @see    JFormFieldContentLanguage for a select list of content languages.
  * @since  1.0
  */
 class LanguageField extends ListField

--- a/src/Field/ListField.php
+++ b/src/Field/ListField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,7 +11,8 @@ namespace Joomla\Form\Field;
 use Joomla\Form\Html\Select as HtmlSelect;
 
 /**
- * Form Field class for the Joomla Framework.
+ * List Form Field class for the Joomla! Framework.
+ *
  * Supports a generic list of options.
  *
  * @since  1.0
@@ -28,6 +29,7 @@ class ListField extends \Joomla\Form\Field
 
 	/**
 	 * Method to get the field input markup for a generic list.
+	 *
 	 * Use the multiple attribute to enable multiselect.
 	 *
 	 * @return  string  The field input markup.

--- a/src/Field/PasswordField.php
+++ b/src/Field/PasswordField.php
@@ -13,7 +13,7 @@ namespace Joomla\Form\Field;
  * Text field for passwords
  *
  * @link   http://www.w3.org/TR/html-markup/input.password.html#input.password
- * @note   Two password fields may be validated as matching using JFormRuleEquals
+ * @note   Two password fields may be validated as matching using {@link \Joomla\Form\Rule\Equals}
  * @since  1.0
  */
 class PasswordField extends \Joomla\Form\Field

--- a/src/Field/PasswordField.php
+++ b/src/Field/PasswordField.php
@@ -1,16 +1,17 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Text field for passwords
+ * Password Form Field class for the Joomla! Framework.
+ *
+ * Text field for passwords.
  *
  * @link   http://www.w3.org/TR/html-markup/input.password.html#input.password
  * @note   Two password fields may be validated as matching using {@link \Joomla\Form\Rule\Equals}

--- a/src/Field/RadioField.php
+++ b/src/Field/RadioField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,8 +11,9 @@ namespace Joomla\Form\Field;
 use stdClass;
 
 /**
- * Form Field class for the Joomla Framework.
- * Provides radio button inputs
+ * Radio Form Field class for the Joomla! Framework.
+ *
+ * Provides radio button inputs.
  *
  * @link   http://www.w3.org/TR/html-markup/command.radio.html#command.radio
  * @since  1.0

--- a/src/Field/SpacerField.php
+++ b/src/Field/SpacerField.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Spacer Form Field class for the Joomla! Framework.
+ *
  * Provides spacer markup to be used in form layouts.
  *
  * @since  1.0

--- a/src/Field/TelField.php
+++ b/src/Field/TelField.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Supports a text field telephone numbers.
+ * Telephone Form Field class for the Joomla! Framework.
+ *
+ * Supports an HTML5 text field for telephone numbers.
  *
  * @link   http://www.w3.org/TR/html-markup/input.tel.html
- * @see    \Joomla\Form\Rule\Tel for telephone number validation
+ * @see    \Joomla\Form\Rule\TelRule for telephone number validation
  * @since  1.0
  */
 class TelField extends TextField

--- a/src/Field/TelField.php
+++ b/src/Field/TelField.php
@@ -13,8 +13,7 @@ namespace Joomla\Form\Field;
  * Supports a text field telephone numbers.
  *
  * @link   http://www.w3.org/TR/html-markup/input.tel.html
- * @see    JFormRuleTel for telephone number validation
- * @see    JHtmlTel for rendering of telephone numbers
+ * @see    \Joomla\Form\Rule\Tel for telephone number validation
  * @since  1.0
  */
 class TelField extends TextField

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Text Form Field class for the Joomla! Framework.
+ *
  * Supports a one line text field.
  *
  * @link   http://www.w3.org/TR/html-markup/input.text.html#input.text
@@ -45,7 +46,7 @@ class TextField extends \Joomla\Form\Field
 		// Initialize JavaScript field attributes.
 		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
-		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
+		return '<input type="' . strtolower($this->type) . '" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $onchange . $maxLength . '/>';
 	}
 }

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Text Area Form Field class for the Joomla! Framework.
+ *
  * Supports a multi line area for entry of plain text
  *
  * @link   http://www.w3.org/TR/html-markup/textarea.html#textarea

--- a/src/Field/TimezoneField.php
+++ b/src/Field/TimezoneField.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,7 +11,9 @@ namespace Joomla\Form\Field;
 use Joomla\Form\Html\Select as HtmlSelect;
 
 /**
- * Form Field class for the Joomla Framework.
+ * Timezone Form Field class for the Joomla! Framework.
+ *
+ * Supports a grouped list of timezones.
  *
  * @since  1.0
  */
@@ -29,7 +31,6 @@ class TimezoneField extends GroupedListField
 	 * The list of available timezone groups to use.
 	 *
 	 * @var    array
-	 *
 	 * @since  1.0
 	 */
 	protected static $zones = array('Africa', 'America', 'Antarctica', 'Arctic', 'Asia', 'Atlantic', 'Australia', 'Europe', 'Indian', 'Pacific');

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Field;
 
 /**
- * Form Field class for the Joomla Framework.
- * Supports a URL text field
+ * URL Form Field class for the Joomla! Framework.
+ *
+ * Supports an HTML5 URL text field
  *
  * @link   http://www.w3.org/TR/html-markup/input.url.html#input.url
- * @see    \Joomla\Form\Rule\Url for validation of full urls
+ * @see    \Joomla\Form\Rule\UrlRule for validation of full urls
  * @since  1.0
  */
 class UrlField extends TextField

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -13,7 +13,7 @@ namespace Joomla\Form\Field;
  * Supports a URL text field
  *
  * @link   http://www.w3.org/TR/html-markup/input.url.html#input.url
- * @see    JFormRuleUrl for validation of full urls
+ * @see    \Joomla\Form\Rule\Url for validation of full urls
  * @since  1.0
  */
 class UrlField extends TextField

--- a/src/Form.php
+++ b/src/Form.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -17,11 +17,10 @@ use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
 /**
- * Form Class for the Joomla Framework.
+ * Form Class for the Joomla! Framework.
  *
  * This class implements a robust API for constructing, populating, filtering, and validating forms.
- * It uses XML definitions to construct form fields and a variety of field and rule classes to
- * render and validate the form.
+ * It uses XML definitions to construct form fields and a variety of field and rule classes to render and validate the form.
  *
  * @link   http://www.w3.org/TR/html4/interact/forms.html
  * @link   http://www.w3.org/TR/html5/forms.html
@@ -32,7 +31,7 @@ class Form
 	/**
 	 * The Registry data store for form fields during display.
 	 *
-	 * @var    object
+	 * @var    Registry
 	 * @since  1.0
 	 */
 	protected $data;
@@ -330,12 +329,11 @@ class Form
 	}
 
 	/**
-	 * Method to get an array of FormField objects in a given fieldset by name.  If no name is
-	 * given then all fields are returned.
+	 * Method to get an array of Field objects in a given fieldset by name.  If no name is given then all fields are returned.
 	 *
 	 * @param   string  $set  The optional name of the fieldset.
 	 *
-	 * @return  array  The array of FormField objects in the fieldset.
+	 * @return  Field[]  An array of Field objects in the fieldset.
 	 *
 	 * @since   1.0
 	 */
@@ -499,13 +497,14 @@ class Form
 	}
 
 	/**
-	 * Method to set the form control. This string serves as a container for all form fields. For
-	 * example, if there is a field named 'foo' and a field named 'bar' and the form control is
-	 * empty the fields will be rendered like: <input name="foo" /> and <input name="bar" />.  If
-	 * the form control is set to 'joomla' however, the fields would be rendered like:
-	 * <input name="joomla[foo]" /> and <input name="joomla[bar]" />.
+	 * Method to set the form control
 	 *
-	 * @return  static
+	 * This string serves as a container for all form fields. For example, if there is a field named 'foo'
+	 * and a field named 'bar' and the form control is empty the fields will be rendered like:
+	 * <input name="foo" /> and <input name="bar" />.  If the form control is set to 'joomla' however, the fields
+	 * would be rendered like: <input name="joomla[foo]" /> and <input name="joomla[bar]" />.
+	 *
+	 * @return  Form
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -517,11 +516,12 @@ class Form
 	 }
 
 	/**
-	 * Method to get the form control. This string serves as a container for all form fields. For
-	 * example, if there is a field named 'foo' and a field named 'bar' and the form control is
-	 * empty the fields will be rendered like: <input name="foo" /> and <input name="bar" />.  If
-	 * the form control is set to 'joomla' however, the fields would be rendered like:
-	 * <input name="joomla[foo]" /> and <input name="joomla[bar]" />.
+	 * Method to get the form control.
+	 *
+	 * This string serves as a container for all form fields. For example, if there is a field named 'foo'
+	 * and a field named 'bar' and the form control is empty the fields will be rendered like:
+	 * <input name="foo" /> and <input name="bar" />.  If the form control is set to 'joomla' however, the fields
+	 * would be rendered like: <input name="joomla[foo]" /> and <input name="joomla[bar]" />.
 	 *
 	 * @return  string  The form control string.
 	 *
@@ -533,13 +533,13 @@ class Form
 	}
 
 	/**
-	 * Method to get an array of FormField objects in a given field group by name.
+	 * Method to get an array of Field objects in a given field group by name.
 	 *
 	 * @param   string   $group   The dot-separated form group path for which to get the form fields.
 	 * @param   boolean  $nested  True to also include fields in nested groups that are inside of the
 	 *                            group for which to find fields.
 	 *
-	 * @return  array    The array of FormField objects in the field group.
+	 * @return  Field[]  The array of Field objects in the field group.
 	 *
 	 * @since   1.0
 	 */
@@ -675,10 +675,10 @@ class Form
 	 * field being loaded.  If it is false, then the new field being loaded will be ignored and the
 	 * method will move on to the next field to load.
 	 *
-	 * @param   string       $data     The name of an XML string or object.
-	 * @param   boolean      $replace  Flag to toggle whether form fields should be replaced if a field
-	 *                                 already exists with the same group/name.
-	 * @param   bool|string  $xpath    An optional xpath to search for the fields.
+	 * @param   string          $data     The name of an XML string or object.
+	 * @param   boolean         $replace  Flag to toggle whether form fields should be replaced if a field
+	 *                                    already exists with the same group/name.
+	 * @param   boolean|string  $xpath    An optional xpath to search for the fields.
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
@@ -798,10 +798,10 @@ class Form
 	 * fields in the new XML file unless the $reset parameter has been set
 	 * to false.
 	 *
-	 * @param   string       $file   The filesystem path of an XML file.
-	 * @param   boolean      $reset  Flag to toggle whether form fields should be replaced if a field
-	 *                               already exists with the same group/name.
-	 * @param   bool|string  $xpath  An optional xpath to search for the fields.
+	 * @param   string          $file   The filesystem path of an XML file.
+	 * @param   boolean         $reset  Flag to toggle whether form fields should be replaced if a field
+	 *                                  already exists with the same group/name.
+	 * @param   boolean|string  $xpath  An optional xpath to search for the fields.
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
@@ -1395,7 +1395,7 @@ class Form
 	 * @param   string  $name   The name of the form field.
 	 * @param   string  $group  The optional dot-separated form group path on which to find the field.
 	 *
-	 * @return  mixed  The XML element object for the field or boolean false on error.
+	 * @return  \SimpleXMLElement|boolean  Boolean false on error or a SimpleXMLElement object.
 	 *
 	 * @since   1.0
 	 */
@@ -1488,7 +1488,7 @@ class Form
 	 *
 	 * @param   string  $name  The name of the fieldset.
 	 *
-	 * @return  mixed  Boolean false on error or array of SimpleXMLElement objects.
+	 * @return  \SimpleXMLElement[]|boolean  Boolean false on error or array of SimpleXMLElement objects.
 	 *
 	 * @since   1.0
 	 */
@@ -1522,7 +1522,7 @@ class Form
 	 * @param   boolean  $nested  True to also include fields in nested groups that are inside of the
 	 *                            group for which to find fields.
 	 *
-	 * @return  mixed  Boolean false on error or array of SimpleXMLElement objects.
+	 * @return  \SimpleXMLElement[]|boolean  Boolean false on error or array of SimpleXMLElement objects.
 	 *
 	 * @since   1.0
 	 */
@@ -1595,7 +1595,7 @@ class Form
 	 *
 	 * @param   string  $group  The dot-separated form group path on which to find the group.
 	 *
-	 * @return  mixed  An array of XML element objects for the group or boolean false on error.
+	 * @return  \SimpleXMLElement[]|boolean  Boolean false on error or array of SimpleXMLElement objects.
 	 *
 	 * @since   1.0
 	 */
@@ -1807,7 +1807,7 @@ class Form
 	 * @param   Registry           $input    An optional Registry object with the entire data set to validate
 	 *                                       against the entire form.
 	 *
-	 * @return  mixed  Boolean true if field value is valid, Exception on failure.
+	 * @return  \Exception|boolean  Boolean true if field value is valid, Exception on failure.
 	 *
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException

--- a/src/FormHelper.php
+++ b/src/FormHelper.php
@@ -103,10 +103,7 @@ class FormHelper
 			$class .=  '\\' . ucfirst($type);
 		}
 
-		if ($entity === 'field')
-		{
-			$class .= ucfirst($entity);
-		}
+		$class .= ucfirst($entity);
 
 		// Check for all if the class exists.
 		return class_exists($class) ? $class : false;

--- a/src/FormHelper.php
+++ b/src/FormHelper.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -13,6 +13,7 @@ use Joomla\String\String;
 
 /**
  * Helper class for the Form package.
+ *
  * Provides a storage for filesystem's paths where Joomla\Form entities reside and methods for creating those entities.
  * Also stores objects with entities' prototypes for further reusing.
  *
@@ -39,6 +40,7 @@ class FormHelper
 
 	/**
 	 * Attempt to import the Field class file if it isn't already imported.
+	 *
 	 * You can use this method outside of Joomla\Form for loading a field for inheritance or composition.
 	 *
 	 * @param   string  $type  Type of a field whose class should be loaded.
@@ -54,6 +56,7 @@ class FormHelper
 
 	/**
 	 * Attempt to import the Rule class file if it isn't already imported.
+	 *
 	 * You can use this method outside of Joomla\Form for loading a rule for inheritance or composition.
 	 *
 	 * @param   string  $type  Type of a rule whose class should be loaded.
@@ -76,7 +79,7 @@ class FormHelper
 	 * @param   string  $entity  One of the form entities (field or rule).
 	 * @param   string  $type    Type of an entity.
 	 *
-	 * @return  mixed  Class name on success or false otherwise.
+	 * @return  boolean|string  Class name on success or false otherwise.
 	 *
 	 * @since   1.0
 	 */

--- a/src/Html/Select.php
+++ b/src/Html/Select.php
@@ -71,7 +71,18 @@ class Select
 	 */
 	public function booleanlist($name, $attribs = null, $selected = null, $yes = 'JYES', $no = 'JNO', $id = false)
 	{
-		$arr = array($this->option('0', $this->text->translate($no)), $this->option('1', $this->text->translate($yes)));
+		try
+		{
+			$optionNoText  = $this->getText()->translate($no);
+			$optionYesText = $this->getText()->translate($yes);
+		}
+		catch (\RuntimeException $exception)
+		{
+			$optionNoText  = $no;
+			$optionYesText = $yes;
+		}
+
+		$arr = array($this->option('0', $optionNoText), $this->option('1', $optionYesText));
 
 		return $this->radiolist($arr, $name, $attribs, 'value', 'text', (int) $selected, $id);
 	}
@@ -196,7 +207,7 @@ class Select
 	 *                            list.select: either the value of one selected option or an array
 	 *                            of selected options. Default: none.
 	 *                            list.translate: Boolean. If set, text and labels are translated via
-	 *                            $this->text->translate().
+	 *                            {@see \Joomla\Language\Text::translate()}.
 	 *
 	 * @return  string  HTML for the select list
 	 *
@@ -496,7 +507,7 @@ class Select
 	 *                               -list.select: either the value of one selected option or an array
 	 *                                of selected options. Default: none.
 	 *                               -list.translate: Boolean. If set, text and labels are translated via
-	 *                                $this->text->translate(). Default is false.
+	 *                                {@see \Joomla\Language\Text::translate()}. Default is false.
 	 *                               -option.id: The property in each option array to use as the
 	 *                                selection id attribute. Defaults to none.
 	 *                               -option.key: The property in each option array to use as the
@@ -605,7 +616,7 @@ class Select
 
 			if ($options['groups'] && $key == '<OPTGROUP>')
 			{
-				$html .= $baseIndent . '<optgroup label="' . ($options['list.translate'] ? $this->text->translate($text) : $text) . '">' . $options['format.eol'];
+				$html .= $baseIndent . '<optgroup label="' . ($options['list.translate'] ? $this->getText()->translate($text) : $text) . '">' . $options['format.eol'];
 				$baseIndent = str_repeat($options['format.indent'], ++$options['format.depth']);
 			}
 			elseif ($options['groups'] && $key == '</OPTGROUP>')
@@ -626,7 +637,7 @@ class Select
 
 				if ($options['list.translate'] && !empty($label))
 				{
-					$label = $this->text->translate($label);
+					$label = $this->getText()->translate($label);
 				}
 
 				if ($options['option.label.toHtml'])
@@ -665,7 +676,7 @@ class Select
 
 				if ($options['list.translate'])
 				{
-					$text = $this->text->translate($text);
+					$text = $this->getText()->translate($text);
 				}
 
 				// Generate the option, encoding as required
@@ -711,7 +722,7 @@ class Select
 		foreach ($data as $obj)
 		{
 			$k = $obj->$optKey;
-			$t = $translate ? $this->text->translate($obj->$optText) : $obj->$optText;
+			$t = $translate ? $this->getText()->translate($obj->$optText) : $obj->$optText;
 			$id = (isset($obj->id) ? $obj->id : null);
 
 			$extra = '';
@@ -750,7 +761,7 @@ class Select
 	 *
 	 * @param   Text  $text  The Text object to store
 	 *
-	 * @return  Field  Instance of this class.
+	 * @return  Select  Instance of this class.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/src/Html/Select.php
+++ b/src/Html/Select.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1,17 +1,14 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form;
 
-
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
-use UnexpectedValueException;
 
 // Detect if we have full UTF-8 and unicode PCRE support.
 if (!defined('JCOMPAT_UNICODE_PROPERTIES'))
@@ -20,7 +17,7 @@ if (!defined('JCOMPAT_UNICODE_PROPERTIES'))
 }
 
 /**
- * Form Rule class for the Joomla Framework.
+ * Form Rule class for the Joomla! Framework.
  *
  * @since  1.0
  */
@@ -45,25 +42,25 @@ abstract class Rule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
-	 * @throws  UnexpectedValueException if rule is invalid.
+	 * @throws  \UnexpectedValueException if rule is invalid.
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		// Check for a valid regex.
 		if (empty($this->regex))
 		{
-			throw new UnexpectedValueException(sprintf('%s has invalid regex.', get_class($this)));
+			throw new \UnexpectedValueException(sprintf('%s has invalid regex.', get_class($this)));
 		}
 
 		// Add unicode property support if available.

--- a/src/Rule/BooleanRule.php
+++ b/src/Rule/BooleanRule.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,7 +11,9 @@ namespace Joomla\Form\Rule;
 use Joomla\Form\Rule;
 
 /**
- * Form Rule class for the Joomla Framework.
+ * Boolean Form Rule class for the Joomla! Framework.
+ *
+ * Validates that a form field matches a boolean value
  *
  * @since  1.0
  */

--- a/src/Rule/BooleanRule.php
+++ b/src/Rule/BooleanRule.php
@@ -15,7 +15,7 @@ use Joomla\Form\Rule;
  *
  * @since  1.0
  */
-class Boolean extends Rule
+class BooleanRule extends Rule
 {
 	/**
 	 * The regular expression to use in testing a form field value.

--- a/src/Rule/ColorRule.php
+++ b/src/Rule/ColorRule.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -13,7 +13,9 @@ use Joomla\Form\Form;
 use Joomla\Registry\Registry;
 
 /**
- * Form Rule class for the Joomla Framework.
+ * Color Form Rule class for the Joomla! Framework.
+ *
+ * Validates that a value is a valid hexadecimal color code.
  *
  * @since  1.0
  */

--- a/src/Rule/ColorRule.php
+++ b/src/Rule/ColorRule.php
@@ -17,7 +17,7 @@ use Joomla\Registry\Registry;
  *
  * @since  1.0
  */
-class Color extends Rule
+class ColorRule extends Rule
 {
 	/**
 	 * Method to test for a valid color in hexadecimal.

--- a/src/Rule/EmailRule.php
+++ b/src/Rule/EmailRule.php
@@ -18,7 +18,7 @@ use SimpleXMLElement;
  *
  * @since  1.0
  */
-class Email extends Rule
+class EmailRule extends Rule
 {
 	/**
 	 * The regular expression to use in testing a form field value.

--- a/src/Rule/EmailRule.php
+++ b/src/Rule/EmailRule.php
@@ -1,20 +1,21 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Rule;
 
-use Joomla\Form\Rule;
 use Joomla\Form\Form;
+use Joomla\Form\Rule;
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
 
 /**
- * Form Rule class for the Joomla Framework.
+ * E-mail Form Rule class for the Joomla! Framework.
+ *
+ * Validates that a value is in a proper e-mail address format.
  *
  * @since  1.0
  */
@@ -32,19 +33,19 @@ class EmailRule extends Rule
 	/**
 	 * Method to test the email address and optionally check for uniqueness.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/src/Rule/EqualsRule.php
+++ b/src/Rule/EqualsRule.php
@@ -1,22 +1,21 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Rule;
 
-use Joomla\Form\Rule;
 use Joomla\Form\Form;
+use Joomla\Form\Rule;
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
-use UnexpectedValueException;
-use InvalidArgumentException;
 
 /**
- * Form Rule class for the Joomla Framework.
+ * Equals Form Rule class for the Joomla! Framework.
+ *
+ * Validates that two values are equal.
  *
  * @since  1.0
  */
@@ -27,33 +26,33 @@ class EqualsRule extends Rule
 	 * XML needs a validate attribute of equals and a field attribute
 	 * that is equal to the field to test against.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
-	 * @throws  InvalidArgumentException
-	 * @throws  UnexpectedValueException
+	 * @throws  \InvalidArgumentException
+	 * @throws  \UnexpectedValueException
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		$field = (string) $element['field'];
 
 		// Check that a validation field is set.
 		if (!$field)
 		{
-			throw new UnexpectedValueException(sprintf('$field empty in %s::test', get_class($this)));
+			throw new \UnexpectedValueException(sprintf('$field empty in %s::test', get_class($this)));
 		}
 
 		if (is_null($input))
 		{
-			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
+			throw new \InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
 		}
 
 		// Test the two values against each other.

--- a/src/Rule/EqualsRule.php
+++ b/src/Rule/EqualsRule.php
@@ -3,7 +3,7 @@
  * Part of the Joomla Framework Form Package
  *
  * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Form\Rule;
@@ -12,17 +12,20 @@ use Joomla\Form\Rule;
 use Joomla\Form\Form;
 use Joomla\Registry\Registry;
 use SimpleXMLElement;
+use UnexpectedValueException;
+use InvalidArgumentException;
 
 /**
  * Form Rule class for the Joomla Framework.
- * Requires the value entered be one of the options in a field of type="list"
  *
  * @since  1.0
  */
-class Options extends Rule
+class EqualsRule extends Rule
 {
 	/**
-	 * Method to test the value.
+	 * Method to test if two values are equal. To use this rule, the form
+	 * XML needs a validate attribute of equals and a field attribute
+	 * that is equal to the field to test against.
 	 *
 	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
@@ -35,16 +38,28 @@ class Options extends Rule
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
+	 * @throws  InvalidArgumentException
+	 * @throws  UnexpectedValueException
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
-		// Check each value and return true if we get a match
-		foreach ($element->option as $option)
+		$field = (string) $element['field'];
+
+		// Check that a validation field is set.
+		if (!$field)
 		{
-			if ($value == (string) $option->attributes()->value)
-			{
-				return true;
-			}
+			throw new UnexpectedValueException(sprintf('$field empty in %s::test', get_class($this)));
+		}
+
+		if (is_null($input))
+		{
+			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
+		}
+
+		// Test the two values against each other.
+		if ($value == $input->get($field))
+		{
+			return true;
 		}
 
 		return false;

--- a/src/Rule/OptionsRule.php
+++ b/src/Rule/OptionsRule.php
@@ -3,7 +3,7 @@
  * Part of the Joomla Framework Form Package
  *
  * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\Form\Rule;
@@ -12,20 +12,17 @@ use Joomla\Form\Rule;
 use Joomla\Form\Form;
 use Joomla\Registry\Registry;
 use SimpleXMLElement;
-use UnexpectedValueException;
-use InvalidArgumentException;
 
 /**
  * Form Rule class for the Joomla Framework.
+ * Requires the value entered be one of the options in a field of type="list"
  *
  * @since  1.0
  */
-class Equals extends Rule
+class OptionsRule extends Rule
 {
 	/**
-	 * Method to test if two values are equal. To use this rule, the form
-	 * XML needs a validate attribute of equals and a field attribute
-	 * that is equal to the field to test against.
+	 * Method to test the value.
 	 *
 	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
@@ -38,28 +35,16 @@ class Equals extends Rule
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
-	 * @throws  InvalidArgumentException
-	 * @throws  UnexpectedValueException
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
-		$field = (string) $element['field'];
-
-		// Check that a validation field is set.
-		if (!$field)
+		// Check each value and return true if we get a match
+		foreach ($element->option as $option)
 		{
-			throw new UnexpectedValueException(sprintf('$field empty in %s::test', get_class($this)));
-		}
-
-		if (is_null($input))
-		{
-			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
-		}
-
-		// Test the two values against each other.
-		if ($value == $input->get($field))
-		{
-			return true;
+			if ($value == (string) $option->attributes()->value)
+			{
+				return true;
+			}
 		}
 
 		return false;

--- a/src/Rule/OptionsRule.php
+++ b/src/Rule/OptionsRule.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -11,11 +11,11 @@ namespace Joomla\Form\Rule;
 use Joomla\Form\Rule;
 use Joomla\Form\Form;
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
 
 /**
- * Form Rule class for the Joomla Framework.
- * Requires the value entered be one of the options in a field of type="list"
+ * Options Form Rule class for the Joomla! Framework.
+ *
+ * Requires the value entered be one of the options in a list field type.
  *
  * @since  1.0
  */
@@ -24,19 +24,19 @@ class OptionsRule extends Rule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		// Check each value and return true if we get a match
 		foreach ($element->option as $option)

--- a/src/Rule/TelRule.php
+++ b/src/Rule/TelRule.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -11,31 +11,32 @@ namespace Joomla\Form\Rule;
 use Joomla\Form\Rule;
 use Joomla\Form\Form;
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
 
 /**
- * Form Rule class for the Joomla Framework
+ * Telephone Form Rule class for the Joomla! Framework
+ *
+ * Validates that a field's value matches a telephone number pattern.
  *
  * @since  1.0
  */
 class TelRule extends Rule
 {
 	/**
-	 * Method to test the url for a valid parts.
+	 * Method to test the value for a valid parts.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/src/Rule/TelRule.php
+++ b/src/Rule/TelRule.php
@@ -18,7 +18,7 @@ use SimpleXMLElement;
  *
  * @since  1.0
  */
-class Tel extends Rule
+class TelRule extends Rule
 {
 	/**
 	 * Method to test the url for a valid parts.

--- a/src/Rule/UrlRule.php
+++ b/src/Rule/UrlRule.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Part of the Joomla Framework Form Package
+ * Part of the Joomla! Framework Form Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -13,10 +13,11 @@ use Joomla\Form\Rule;
 use Joomla\String\String;
 use Joomla\Uri\UriHelper;
 use Joomla\Registry\Registry;
-use SimpleXMLElement;
 
 /**
- * Form Rule class for the Joomla Framework.
+ * URL Form Rule class for the Joomla! Framework.
+ *
+ * Validates that a field's value is formatted as a valid URL.
  *
  * @since  1.0
  */
@@ -25,21 +26,21 @@ class UrlRule extends Rule
 	/**
 	 * Method to test an external url for a valid parts.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
-	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
-	 * @param   Form              $form     The form object for which the field is being tested.
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   1.0
 	 * @link    http://www.w3.org/Addressing/URL/url-spec.txt
-	 * @see	    Jstring
+	 * @see	    \Joomla\String\String
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/src/Rule/UrlRule.php
+++ b/src/Rule/UrlRule.php
@@ -20,7 +20,7 @@ use SimpleXMLElement;
  *
  * @since  1.0
  */
-class Url extends Rule
+class UrlRule extends Rule
 {
 	/**
 	 * Method to test an external url for a valid parts.


### PR DESCRIPTION
B/C Breaks:
* `FormHelper::loadClass()` will always append the entity to the class name
* Remove support for some properties accepting multiple values (i.e. required could be true, 1, or required; now only true is supported)
* Remove asterisk from labels for required fields and required class from field inputs; the required class does remain on the field's label (this is consistent with Symfony and Twig FWIW)

Miscellaneous:
* Updated doc block references to CMS class names
* General cleanup of doc blocks
