### PR TITLE
Add Field::__isset magic method

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -333,27 +333,13 @@ abstract class Field
 	 */
 	public function __isset($name)
 	{
-		switch ($name)
+		if ($name == 'input' || $name == 'label') {
+			return true;
+		}
+
+		if ($this->$name !== null)
 		{
-			case 'description':
-			case 'formControl':
-			case 'hidden':
-			case 'id':
-			case 'multiple':
-			case 'name':
-			case 'required':
-			case 'disabled':
-			case 'readonly':
-			case 'type':
-			case 'validate':
-			case 'value':
-			case 'labelClass':
-			case 'fieldname':
-			case 'group':
-			case 'input':
-			case 'label':
-			case 'title':
-				return true;
+			return true;
 		}
 
 		return false;

--- a/src/Field.php
+++ b/src/Field.php
@@ -323,6 +323,41 @@ abstract class Field
 
 		return null;
 	}
+	
+	/**
+	 * Method to checks whether the value of certain inaccessible properties has been set or is it null.
+	 *
+	 * @param   string  $name  The property name.
+	 *
+	 * @return  boolean  True if the value is set, false otherwise.
+	 */
+	public function __isset($name)
+	{
+		switch ($name)
+		{
+			case 'description':
+			case 'formControl':
+			case 'hidden':
+			case 'id':
+			case 'multiple':
+			case 'name':
+			case 'required':
+			case 'disabled':
+			case 'readonly':
+			case 'type':
+			case 'validate':
+			case 'value':
+			case 'labelClass':
+			case 'fieldname':
+			case 'group':
+			case 'input':
+			case 'label':
+			case 'title':
+				return true;
+		}
+
+		return false;
+	}
 
 	/**
 	 * Method to attach a Form object to the field.


### PR DESCRIPTION
I'm using Twig as templating engine.
I can't use {{ field.input }} or {{ field.label }} in my templates because Twig checks if the property is defined before calling the magic method Field::__get().
I don't know if this the good way to do this but it works.