### PR TITLE
Markdown fix for badges by updating to current markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # The Form Package [![Build Status](https://travis-ci.org/joomla-framework/form.png?branch=master)](https://travis-ci.org/joomla-framework/form)
-
-[![Latest Stable Version](https://poser.pugx.org/joomla/form/v/stable.svg)](https://packagist.org/packages/joomla/form)
-[![Total Downloads](https://poser.pugx.org/joomla/form/downloads.svg)](https://packagist.org/packages/joomla/form)
-[![Latest Unstable Version](https://poser.pugx.org/joomla/form/v/unstable.svg)](https://packagist.org/packages/joomla/form)
-[![License](https://poser.pugx.org/joomla/form/license.svg)](https://packagist.org/packages/joomla/form)
+[![Latest Stable Version](https://poser.pugx.org/joomla/form/v/stable)](https://packagist.org/packages/joomla/form)
+[![Total Downloads](https://poser.pugx.org/joomla/form/downloads)](https://packagist.org/packages/joomla/form)
+[![Latest Unstable Version](https://poser.pugx.org/joomla/form/v/unstable)](https://packagist.org/packages/joomla/form) [![License](https://poser.pugx.org/joomla/form/license)](https://packagist.org/packages/joomla/form)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/joomla-framework/form/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/joomla-framework/form/?branch=master)
 
 ## Introduction ##

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # The Form Package [![Build Status](https://travis-ci.org/joomla-framework/form.png?branch=master)](https://travis-ci.org/joomla-framework/form)
 [![Latest Stable Version](https://poser.pugx.org/joomla/form/v/stable)](https://packagist.org/packages/joomla/form)
 [![Total Downloads](https://poser.pugx.org/joomla/form/downloads)](https://packagist.org/packages/joomla/form)
-[![Latest Unstable Version](https://poser.pugx.org/joomla/form/v/unstable)](https://packagist.org/packages/joomla/form) [![License](https://poser.pugx.org/joomla/form/license)](https://packagist.org/packages/joomla/form)
+[![Latest Unstable Version](https://poser.pugx.org/joomla/form/v/unstable)](https://packagist.org/packages/joomla/form)
+[![License](https://poser.pugx.org/joomla/form/license)](https://packagist.org/packages/joomla/form)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/joomla-framework/form/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/joomla-framework/form/?branch=master)
 
 ## Introduction ##


### PR DESCRIPTION
The poser badges occasionally will not show up, updating to the current markdown resolves that issue. 