### PR TITLE
Code style for control statement fixed; followed by code simplification.

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -260,9 +260,7 @@ abstract class Field
 				$this->type = '';
 			}
 
-			for($i = 1; $i < count($parts) && $parts[$i] != "Field"; $i++);
-
-			for(; $i < count($parts); $i++)
+			for ($i = array_search('Field', $parts); 0 < $i && $i < count($parts); $i++)
 			{
 				$this->type .= '\\' . StringHelper::ucfirst($parts[$i]);
 			}


### PR DESCRIPTION
Code style for control statement fixed; followed by code simplification.
Actual one was causing Travis build to fail due to inline-control-structure usage and no space before parens of for statements.