### PR TITLE
$fields array was implicitly converted to a boolean

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1430,7 +1430,7 @@ class Form
 			}
 
 			// Make sure something was found.
-			if (!$fields)
+			if (empty($fields))
 			{
 				return false;
 			}
@@ -1459,7 +1459,7 @@ class Form
 			$fields = $this->xml->xpath('//field[@name="' . $name . '"]');
 
 			// Make sure something was found.
-			if (!$fields)
+			if (empty($fields))
 			{
 				return false;
 			}


### PR DESCRIPTION
Best Practice fix: The expression $fields of type array was implicitly converted to a boolean; this is not the Best Practice. Replace `!$fields` with `empty($fields)` to make it clear that we intended to check for an array without elements.