### PR TITLE
Run tests in PHP 5.6/7.0 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
 
 before_script:
   - composer update --dev
 
 script:
-  - phpunit
+  - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
   - composer update --dev
 
 script:
-  - ./vendor/bin/phpunit
+  - vendor/bin/phpunit


### PR DESCRIPTION
- Allow PHP 7 and HHVM tests to fail
- Update phpunit call