### PR TITLE
Skip field validation when it is not requested to be validated

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1158,6 +1158,11 @@ class Form
 			$value = null;
 			$name = (string) $field['name'];
 
+			if (!$input->exists($name))
+			{
+				continue;
+			}
+
 			// Get the group names as strings for ancestor fields elements.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
 			$groups = array_map('strval', $attrs ? $attrs : array());


### PR DESCRIPTION
### Summary of Changes

Skip field validation when it is not requested to be validated

### Testing Instructions

```xml
<form>
	<fields>
		<field name="test1" type="text" validate="int"/>
		<field name="test2" type="text" required="true"/>
		<field name="test3" type="text" validate="tel"/>
	</fields>
</form>
```

```php
$fields = array('test2' => 'joomla-framework');
$valid = $form->validate($fields);
```

### After patch

$valid === true;

### Before the patch

$valid === false;

### Explenation

Please take a look here:
https://github.com/joomla-framework/form/blob/master/src/Form.php#L1156-L1185

In the case you just want to test / validate one field (like the example above) this code loads all fields and try to validatet them. But as there are just one value passed to that method the result is false. This is caused by the foreach checking all fields and throw and error when there is just one error.

The problem here is that we just want to test one field but the code checks all fields (that may contain errors) and not just that one we want to check.

After that patch the method skip the validation if the field is not passed via $data.

### Documentation Changes Required

None