### PR TITLE
Skip validation when the value is empty and not required

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1853,7 +1853,7 @@ class Form
 		}
 
 		// Get the field validation rule.
-		if ($type = (string) $element['validate'])
+		if ($type = (string) $element['validate'] && !empty($value))
 		{
 			// Load the Rule object for the field.
 			$rule = FormHelper::loadRuleClass($type);


### PR DESCRIPTION
### Summary of Changes

Skip validation when the value is empty and not required

### Testing Instructions

```xml
<form>
	<fields>
		<field name="test1" type="text" validate="int"/>
		<field name="test2" type="text" required="true"/>
		<field name="test3" type="text" validate="tel"/>
	</fields>
</form>
```

```php
$fields = array('test3' => '');
$valid = $form->validate($fields);
```

### Before patch

$valid === false;

### After patch

$valid === true;

### Explenation

In this case we want to test one field but for some reason the user did not filled that field. Based on the current logic the validation faild. But as the field is not required also empty should be a valid input for this field.

With this patch we skip the validation when the field value is empty and not required. 

### Documentation Changes Required

none