### PR TITLE
It has a bug in my bugfix, but here's the fix.

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1858,7 +1858,7 @@ class Form
 		}
 
 		// Get the field validation rule.
-		if ($type = (string) $element['validate'] && !empty($value))
+		if (($type = (string) $element['validate']) && !empty($value))
 		{
 			// Load the Rule object for the field.
 			$rule = FormHelper::loadRuleClass($type);


### PR DESCRIPTION
Without the parentheses, $type would be a boolean and not the expected value from $element ['validate'] an validation fails.

see Pull Request for Issue #41
